### PR TITLE
fix: remove duplicate preset key in .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -41,6 +41,5 @@
       "release": "patch"
     }
   ],
-  "tagFormat": "v${version}",
-  "preset": "angular"
+  "tagFormat": "v${version}"
 }


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes the YAML parsing error in the  file that was preventing semantic-release from running in the GitHub Actions workflow.

### **What was fixed:**
- Removed duplicate  entry
- Configuration now validates correctly
- semantic-release can now run without YAML errors

### **Testing:**
- ✅ Local semantic-release dry-run works (configuration loads correctly)
- ✅ Only GitHub token error remains (expected in local environment)
- ✅ Ready for automated releases

### **Files changed:**
-  - Fixed duplicate key issue

This fix ensures the automated release workflow will work properly when the NPM_TOKEN secret is configured.