### PR TITLE
ci: update workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🔧 CI Update

This PR updates the GitHub Actions workflow to use self-hosted runners instead of GitHub-hosted runners.

### **What changed:**
- Updated  from  to 
- This allows the workflow to run on your own infrastructure

### **Why this change:**
- Self-hosted runners can provide better performance
- More control over the build environment
- Potentially faster builds for your specific setup

### **Files changed:**
-  - Updated runner configuration