### PR TITLE
feat: change package name to easy-llm-accessor to resolve npm publishing conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "easy-llm-cli",
+  "name": "easy-llm-accessor",
   "version": "0.0.1",
   "description": "A developer-friendly, configurable LLM client supporting multiple providers, chat, and vision",
   "main": "index.js",


### PR DESCRIPTION
Change package name from 'easy-llm-cli' to 'easy-llm-accessor' to resolve the npm publishing permission issue.

The previous package name 'easy-llm-cli' was already taken or owned by another user, causing a 403 Forbidden error during publishing.

This change should allow the automated release workflow to successfully publish to npm.